### PR TITLE
Fix viewport in sessions.html

### DIFF
--- a/sessions.html
+++ b/sessions.html
@@ -2,11 +2,11 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   <title>Scala関西Summit 2019</title>
-  <link rel="stylesheet" href="./base.css">
-  <link rel="stylesheet" href="./sessions.css">
+  <link rel="stylesheet" href="./base.css" />
+  <link rel="stylesheet" href="./sessions.css" />
   <script src="https://kit.fontawesome.com/a076d05399.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## 目的

トップページと同様、セッション一覧ページも`viewport`の`scale`を`0`にして、スマートフォンから開いた際にワイド表示されるようにしました。